### PR TITLE
fixed bugs preventing compile with Arduino 1.5.7

### DIFF
--- a/Flash.cpp
+++ b/Flash.cpp
@@ -20,7 +20,7 @@
 
 #include "Flash.h"
 
-_FLASH_STRING::_FLASH_STRING(const prog_char *arr) : _arr(arr) 
+_FLASH_STRING::_FLASH_STRING(const char *arr PROGMEM) : _arr(arr) 
 { }
 
 void _FLASH_STRING::print(Print &stream) const

--- a/Flash.h
+++ b/Flash.h
@@ -67,18 +67,18 @@ public:
 class _FLASH_STRING : public _Printable
 {
 public:
-  _FLASH_STRING(const prog_char *arr);
+  _FLASH_STRING(const char *arr PROGMEM);
 
   size_t length() const 
   { return strlen_P(_arr); }
 
   char *copy(char *to, size_t size = -1, size_t offset = 0) const 
   { 
-    return size == -1 ?
+    return size == (size_t)-1 ?
       strcpy_P(to, _arr + offset) : strncpy_P(to, _arr + offset, size);
   }
 
-  const prog_char *access() const 
+  const char *access() const PROGMEM 
   { return _arr; }
 
   const _Printable &Printable() const
@@ -90,7 +90,7 @@ public:
   void print(Print &stream) const;
 
 private:
-  const prog_char *_arr;
+  const char *_arr PROGMEM;;
 };
 
 /* _FLASH_ARRAY template class.  Use the FLASH_ARRAY() macro to create these. */
@@ -180,7 +180,7 @@ private:
 class _FLASH_STRING_ARRAY : public _Printable
 {
 public:
-  _FLASH_STRING_ARRAY(const prog_char **arr, size_t count) : _arr(arr), _size(count)
+  _FLASH_STRING_ARRAY(const char **arr PROGMEM, size_t count) : _arr(arr), _size(count)
   { }
 
   size_t count() const 
@@ -200,7 +200,7 @@ public:
   }
 
 private:
-  const prog_char **_arr;
+  const char **_arr PROGMEM;
   size_t _size;
 };
 


### PR DESCRIPTION
Hi Mikal, I just tried to use Flash in the Arduino 1.5.7 beta. A number of compiler errors prevents your example sketches from compiling. I assume that it's specific to the later versions of the Arduino toolchain. I noticed on [your website that Liss posted a number of fixes](http://arduiniana.org/libraries/flash/) for items that were previously compiler warnings. I implemented those fixes in this fork, and now Flash compiles and seems to operate correctly in 1.5.7.  I take no credit for identifying these changes, but I thought I'd make them available to you in github in case that's easier for you to evaluate them. 
